### PR TITLE
fix: guard firebase messaging for SSR

### DIFF
--- a/webrtc-client/lib/firebase.ts
+++ b/webrtc-client/lib/firebase.ts
@@ -12,6 +12,10 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig)
-const messaging = getMessaging(app)
+
+// `firebase/messaging` relies on browser APIs that aren't available during
+// server‑side rendering. Initialising it only when `window` is defined prevents
+// build‑time crashes on platforms like Vercel.
+const messaging = typeof window !== 'undefined' ? getMessaging(app) : null
 
 export { messaging, getToken, onMessage }


### PR DESCRIPTION
## Summary
- initialize Firebase Cloud Messaging only in the browser to avoid server-side build errors

## Testing
- `npm run build` *(fails to fetch Google Fonts: "Failed to fetch font `Geist`")*


------
https://chatgpt.com/codex/tasks/task_e_688e45deaf24832fa681d34d9c3e3a54